### PR TITLE
Add bootstrap callback

### DIFF
--- a/settings_services.py
+++ b/settings_services.py
@@ -11,3 +11,7 @@ _service_to_command = {
         join(split(__file__)[0], 'ns_always_txtorcon.py'),
     ],
 }
+
+
+def _bootstrap_callback():
+    pass


### PR DESCRIPTION
This allows unpausing Electrum-NMC's network as soon as Tor is bootstrapped, which speeds up initial syncup substantially.