### PR TITLE
Use StreamStatus.CONTROLLER_WAIT

### DIFF
--- a/poc.py
+++ b/poc.py
@@ -253,16 +253,8 @@ cleared.  Maybe you have an outdated Tor daemon?")
     def attach_stream(self, stream):
         print("attach_stream {}".format(stream))
 
-        # Don't attach streams if their status indicates that they were already
-        # attached.
-        if stream.status not in [stem.StreamStatus.NEW,
-                                 stem.StreamStatus.NEWRESOLVE]:
-            return
-
-        # Don't attach streams if their purpose indicates that they will be
-        # automatically attached.
-        if stream.purpose not in [stem.StreamPurpose.DNS_REQUEST,
-                                  stem.StreamPurpose.USER]:
+        # Only attach streams that are waiting for us to attach them.
+        if stream.status != stem.StreamStatus.CONTROLLER_WAIT:
             return
 
         try:


### PR DESCRIPTION
Instead of rolling our own simulation of `__LeaveStreamsUnattached` based on a whitelist of `StreamStatus` and `StreamPurpose`, switch to only checking for the new `CONTROLLER_WAIT` `StreamStatus`, which will be released in Tor 0.4.5.1 Alpha and whatever release branches from Stem master after Stem 1.8.0 branched.

Note that this change makes StemNS incompatible with Tor 0.4.5.0, Stem 1.8.0, and earlier.